### PR TITLE
Add CI job to build generic Docker image of visu-back

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ build:
     DOCKER_DRIVER: overlay2
     REGISTRY_URL: registry.makina-corpus.net
     # These 2 variables are defined in GitLab CI's settings
-    REGISTRY_USER:
-    REGISTRY_PASSWD:
+    REGISTRY_USER: ""
+    REGISTRY_PASSWD: ""
     DOCKER_IMAGE: "${REGISTRY_URL}/terralego/visu-back"
   before_script:
     - echo "${REGISTRY_PASSWD}" |docker login -u ${REGISTRY_USER} --password-stdin ${REGISTRY_URL}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,9 @@ build:
   variables:
     DOCKER_DRIVER: overlay2
     REGISTRY_URL: registry.makina-corpus.net
+    # These 2 variables are defined in GitLab CI's settings
+    REGISTRY_USER:
+    REGISTRY_PASSWD:
     DOCKER_IMAGE: "${REGISTRY_URL}/terralego/visu-back"
   before_script:
     - echo "${REGISTRY_PASSWD}" |docker login -u ${REGISTRY_USER} --password-stdin ${REGISTRY_URL}
@@ -15,6 +18,7 @@ build:
     - docker pull "${DOCKER_IMAGE}:latest" || true
     - docker build --cache-from "${DOCKER_IMAGE}:latest" --tag "${DOCKER_IMAGE}:latest" .
     - docker tag "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:${CI_COMMIT_REF_NAME}"
-    - docker push "${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}"
+    - docker push "${DOCKER_IMAGE}:latest"
+    - docker push "${DOCKER_IMAGE}:${CI_COMMIT_REF_NAME}"
   #only:
   #  - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,5 +20,5 @@ build:
     - docker tag "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:${CI_COMMIT_REF_NAME}"
     - docker push "${DOCKER_IMAGE}:latest"
     - docker push "${DOCKER_IMAGE}:${CI_COMMIT_REF_NAME}"
-  #only:
-  #  - master
+  only:
+    - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,20 @@
-image: ubuntu:18.04
-stages:
-  - manual_jobs
-  - build
-  - tests
-  - flag_success
-  - release
-  - teardown
-  - deploy
+build:
+  image: docker:stable
+  tags:
+    - shared-ci-docker
+  services:
+    - docker:dind
+  variables:
+    DOCKER_DRIVER: overlay2
+    REGISTRY_URL: registry.makina-corpus.net
+    DOCKER_IMAGE: "${REGISTRY_URL}/terralego/visu-back"
+  before_script:
+    - echo "${REGISTRY_PASSWD}" |docker login -u ${REGISTRY_USER} --password-stdin ${REGISTRY_URL}
+  script:
+    # Reuse latest available image for build
+    - docker pull "${DOCKER_IMAGE}:latest" || true
+    - docker build --cache-from "${DOCKER_IMAGE}:latest" --tag "${DOCKER_IMAGE}:latest" .
+    - docker tag "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:${CI_COMMIT_REF_NAME}"
+    - docker push "${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}"
+  #only:
+  #  - master


### PR DESCRIPTION
This is required for cypress job in visu-front CI to work, as it will pull this Docker image.