### PR TITLE
Upgrade django-geosource from 0.4.10 to 0.4.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,119 +4,343 @@
 #
 #    pip-compile
 #
-aiofiles==0.6.0           # via sanic
-aiohttp==3.7.3            # via bygfiles, pyfiles
-amqp==5.0.2               # via kombu
-appdirs==1.4.4            # via fs
-async-timeout==3.0.1      # via aiohttp
-attrs==20.3.0             # via aiohttp, fiona, jsonschema, pytest
-begins==0.9               # via bygfiles, pyfiles
-billiard==3.6.3.0         # via celery
-bonobo==0.6.4             # via terra-bonobo-nodes
-boto3==1.16.31            # via bygfiles, pyfiles
-botocore==1.19.31         # via boto3, s3transfer
-bygfiles==0.1.1           # via terra-bonobo-nodes
-cached-property==1.5.2    # via django-url-filter
-celery==5.0.4             # via -r requirements.in, django-geosource, django-geostore
-certifi==2020.12.5        # via elasticsearch, fiona, httpx, requests
-chardet==3.0.4            # via aiohttp, requests
-click-didyoumean==0.0.3   # via celery
-click-plugins==1.1.1      # via celery, fiona
-click-repl==0.1.6         # via celery
-click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl, cligj, fiona, mercantile
-cligj==0.7.1              # via fiona
-colorama==0.4.4           # via mondrian
-deepmerge==0.1.1          # via django-geostore
-django-cors-headers==2.5.3  # via -r requirements.in
-django-db-geventpool==3.1.0  # via -r requirements.in
-django-filter==2.4.0      # via django-geostore
-django-geosource==0.4.10  # via terra-layer
-django-geostore==0.5.4    # via terra-bonobo-nodes, terra-layer
-django-mapbox-baselayer==0.0.8  # via django-terra-settings, terra-layer
-django-polymorphic==3.0.0  # via django-geosource
-django-redis==4.10.0      # via -r requirements.in
-django-terra-accounts==1.0.2  # via -r requirements.in, terra-layer
-django-terra-settings==1.0.1  # via -r requirements.in, django-terra-accounts, terra-layer
-django-token-tools==0.1.2  # via django-geostore
-django-url-filter==0.3.15  # via django-terra-accounts
-django==2.2.17            # via -r requirements.in, django-cors-headers, django-db-geventpool, django-filter, django-geosource, django-geostore, django-mapbox-baselayer, django-polymorphic, django-redis, django-terra-accounts, django-terra-settings, django-token-tools, django-url-filter, terra-bonobo-nodes, terra-layer
-djangorestframework-gis==0.16  # via django-geostore
-djangorestframework-jwt==1.11.0  # via django-terra-accounts
-djangorestframework==3.10.3  # via django-geosource, django-geostore, django-terra-accounts, django-terra-settings, djangorestframework-gis, terra-layer
-dnspython==2.0.0          # via eventlet
-elasticsearch==7.10.0     # via -r requirements.in, terra-bonobo-nodes
-enum-compat==0.0.3        # via django-url-filter
-eventlet==0.24.1          # via -r requirements.in
-fiona==1.8.18             # via django-geosource, django-geostore
-fs==2.4.11                # via bonobo
-future==0.18.2            # via -r requirements.in
-gevent==1.4.0             # via gunicorn
-gpxpy==1.4.2              # via django-geostore
-graphviz==0.8.4           # via bonobo
-greenlet==0.4.17          # via eventlet, gevent
-gunicorn[gevent]==19.8.1  # via -r requirements.in
-h11==0.9.0                # via httpcore
-httpcore==0.11.1          # via httpx
-httptools==0.1.1          # via sanic
-httpx==0.15.4             # via sanic
-idna==2.10                # via requests, rfc3986, yarl
-iniconfig==1.1.1          # via pytest
-jinja2==2.11.2            # via bonobo
-jmespath==0.10.0          # via boto3, botocore
-jsonschema==3.2.0         # via django-geostore, terra-layer
-kombu==5.0.2              # via celery
-lml==0.1.0                # via pyexcel, pyexcel-io
-markupsafe==1.1.1         # via jinja2
-mercantile==1.1.6         # via django-geostore
-mondrian==0.8.1           # via bonobo
-monotonic==1.5            # via eventlet
-multidict==5.0.0          # via aiohttp, sanic, yarl
-munch==2.5.0              # via fiona
-packaging==19.2           # via bonobo, pytest
-pbr==5.5.1                # via stevedore
-pillow==8.0.1             # via django-geostore
-pluggy==0.13.1            # via pytest
-prompt-toolkit==3.0.8     # via click-repl
-psutil==5.7.3             # via bonobo
-psycogreen==1.0.2         # via django-db-geventpool
-psycopg2==2.8.6           # via django-geosource, django-geostore, django-terra-accounts, django-terra-settings, terra-bonobo-nodes
-py==1.9.0                 # via pytest
-pyexcel-io==0.6.4         # via pyexcel
-pyexcel==0.6.6            # via django-geosource
-git+git://github.com/jrmi/pyfiles@master  # via -r requirements.in
-pyjwt==1.7.1              # via djangorestframework-jwt
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via jsonschema
-pytest==6.1.2             # via terra-bonobo-nodes
-python-dateutil==2.8.1    # via botocore
-python-magic==0.4.18      # via django-terra-settings
-python-slugify==1.2.6     # via bonobo
-pytz==2020.4              # via celery, django, fs
-raven==6.10.0             # via -r requirements.in
-redis==3.5.3              # via django-redis
-requests==2.25.0          # via bonobo, django-geostore, terra-bonobo-nodes
-rfc3986[idna2008]==1.4.0  # via httpx
-s3transfer==0.3.3         # via boto3
-sanic==20.9.1             # via bygfiles, pyfiles
-simplekml==1.3.5          # via django-geostore
-six==1.15.0               # via click-repl, django-url-filter, eventlet, fiona, fs, jsonschema, munch, packaging, python-dateutil, stevedore
-sniffio==1.2.0            # via httpcore, httpx
-sqlparse==0.4.1           # via django
-stevedore==1.32.0         # via bonobo
-terra-bonobo-nodes==0.5.6  # via -r requirements.in
-terra-layer==0.7.6        # via -r requirements.in
-texttable==1.6.3          # via pyexcel
-toml==0.10.2              # via pytest
-typing-extensions==3.7.4.3  # via aiohttp
-ujson==4.0.1              # via sanic
-unidecode==1.1.1          # via python-slugify
-urllib3==1.26.2           # via -r requirements.in, botocore, elasticsearch, requests
-uvloop==0.14.0            # via sanic
-vine==5.0.0               # via amqp, celery
-wcwidth==0.2.5            # via prompt-toolkit
-websockets==8.1           # via sanic
-whistle==1.0.1            # via bonobo
-yarl==1.6.3               # via aiohttp
+aiofiles==0.6.0
+    # via sanic
+aiohttp==3.7.3
+    # via
+    #   bygfiles
+    #   pyfiles
+amqp==5.0.2
+    # via kombu
+appdirs==1.4.4
+    # via fs
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.3.0
+    # via
+    #   aiohttp
+    #   fiona
+    #   jsonschema
+    #   pytest
+begins==0.9
+    # via
+    #   bygfiles
+    #   pyfiles
+billiard==3.6.3.0
+    # via celery
+bonobo==0.6.4
+    # via terra-bonobo-nodes
+boto3==1.16.31
+    # via
+    #   bygfiles
+    #   pyfiles
+botocore==1.19.31
+    # via
+    #   boto3
+    #   s3transfer
+bygfiles==0.1.1
+    # via terra-bonobo-nodes
+cached-property==1.5.2
+    # via django-url-filter
+celery==5.0.4
+    # via
+    #   -r requirements.in
+    #   django-geosource
+    #   django-geostore
+certifi==2020.12.5
+    # via
+    #   elasticsearch
+    #   fiona
+    #   httpx
+    #   requests
+chardet==3.0.4
+    # via
+    #   aiohttp
+    #   requests
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via
+    #   celery
+    #   fiona
+click-repl==0.1.6
+    # via celery
+click==7.1.2
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   cligj
+    #   fiona
+    #   mercantile
+cligj==0.7.1
+    # via fiona
+colorama==0.4.4
+    # via mondrian
+deepmerge==0.1.1
+    # via django-geostore
+django-cors-headers==2.5.3
+    # via -r requirements.in
+django-db-geventpool==3.1.0
+    # via -r requirements.in
+django-filter==2.4.0
+    # via django-geostore
+django-geosource==0.4.11
+    # via terra-layer
+django-geostore==0.5.4
+    # via
+    #   terra-bonobo-nodes
+    #   terra-layer
+django-mapbox-baselayer==0.0.8
+    # via
+    #   django-terra-settings
+    #   terra-layer
+django-polymorphic==3.0.0
+    # via django-geosource
+django-redis==4.10.0
+    # via -r requirements.in
+django-terra-accounts==1.0.2
+    # via
+    #   -r requirements.in
+    #   terra-layer
+django-terra-settings==1.0.1
+    # via
+    #   -r requirements.in
+    #   django-terra-accounts
+    #   terra-layer
+django-token-tools==0.1.2
+    # via django-geostore
+django-url-filter==0.3.15
+    # via django-terra-accounts
+django==2.2.17
+    # via
+    #   -r requirements.in
+    #   django-cors-headers
+    #   django-db-geventpool
+    #   django-filter
+    #   django-geosource
+    #   django-geostore
+    #   django-mapbox-baselayer
+    #   django-polymorphic
+    #   django-redis
+    #   django-terra-accounts
+    #   django-terra-settings
+    #   django-token-tools
+    #   django-url-filter
+    #   terra-bonobo-nodes
+    #   terra-layer
+djangorestframework-gis==0.16
+    # via django-geostore
+djangorestframework-jwt==1.11.0
+    # via django-terra-accounts
+djangorestframework==3.10.3
+    # via
+    #   django-geosource
+    #   django-geostore
+    #   django-terra-accounts
+    #   django-terra-settings
+    #   djangorestframework-gis
+    #   terra-layer
+dnspython==2.0.0
+    # via eventlet
+elasticsearch==7.10.0
+    # via
+    #   -r requirements.in
+    #   terra-bonobo-nodes
+enum-compat==0.0.3
+    # via django-url-filter
+eventlet==0.24.1
+    # via -r requirements.in
+fiona==1.8.18
+    # via
+    #   django-geosource
+    #   django-geostore
+fs==2.4.11
+    # via bonobo
+future==0.18.2
+    # via -r requirements.in
+gevent==1.4.0
+    # via gunicorn
+gpxpy==1.4.2
+    # via django-geostore
+graphviz==0.8.4
+    # via bonobo
+greenlet==0.4.17
+    # via
+    #   eventlet
+    #   gevent
+gunicorn[gevent]==19.8.1
+    # via -r requirements.in
+h11==0.9.0
+    # via httpcore
+httpcore==0.11.1
+    # via httpx
+httptools==0.1.1
+    # via sanic
+httpx==0.15.4
+    # via sanic
+idna==2.10
+    # via
+    #   requests
+    #   rfc3986
+    #   yarl
+iniconfig==1.1.1
+    # via pytest
+jinja2==2.11.2
+    # via bonobo
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+jsonschema==3.2.0
+    # via
+    #   django-geostore
+    #   terra-layer
+kombu==5.0.2
+    # via celery
+lml==0.1.0
+    # via
+    #   pyexcel
+    #   pyexcel-io
+markupsafe==1.1.1
+    # via jinja2
+mercantile==1.1.6
+    # via django-geostore
+mondrian==0.8.1
+    # via bonobo
+monotonic==1.5
+    # via eventlet
+multidict==5.0.0
+    # via
+    #   aiohttp
+    #   sanic
+    #   yarl
+munch==2.5.0
+    # via fiona
+packaging==19.2
+    # via
+    #   bonobo
+    #   pytest
+pbr==5.5.1
+    # via stevedore
+pillow==8.0.1
+    # via django-geostore
+pluggy==0.13.1
+    # via pytest
+prompt-toolkit==3.0.8
+    # via click-repl
+psutil==5.7.3
+    # via bonobo
+psycogreen==1.0.2
+    # via django-db-geventpool
+psycopg2==2.8.6
+    # via
+    #   django-geosource
+    #   django-geostore
+    #   django-terra-accounts
+    #   django-terra-settings
+    #   terra-bonobo-nodes
+py==1.9.0
+    # via pytest
+pyexcel-io==0.6.4
+    # via pyexcel
+pyexcel==0.6.6
+    # via django-geosource
+git+git://github.com/jrmi/pyfiles@master
+    # via -r requirements.in
+pyjwt==1.7.1
+    # via djangorestframework-jwt
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via jsonschema
+pytest==6.1.2
+    # via terra-bonobo-nodes
+python-dateutil==2.8.1
+    # via botocore
+python-magic==0.4.18
+    # via django-terra-settings
+python-slugify==1.2.6
+    # via bonobo
+pytz==2020.4
+    # via
+    #   celery
+    #   django
+    #   fs
+raven==6.10.0
+    # via -r requirements.in
+redis==3.5.3
+    # via django-redis
+requests==2.25.0
+    # via
+    #   bonobo
+    #   django-geostore
+    #   terra-bonobo-nodes
+rfc3986[idna2008]==1.4.0
+    # via httpx
+s3transfer==0.3.3
+    # via boto3
+sanic==20.9.1
+    # via
+    #   bygfiles
+    #   pyfiles
+simplekml==1.3.5
+    # via django-geostore
+six==1.15.0
+    # via
+    #   click-repl
+    #   django-url-filter
+    #   eventlet
+    #   fiona
+    #   fs
+    #   jsonschema
+    #   munch
+    #   packaging
+    #   python-dateutil
+    #   stevedore
+sniffio==1.2.0
+    # via
+    #   httpcore
+    #   httpx
+sqlparse==0.4.1
+    # via django
+stevedore==1.32.0
+    # via bonobo
+terra-bonobo-nodes==0.5.6
+    # via -r requirements.in
+terra-layer==0.7.6
+    # via -r requirements.in
+texttable==1.6.3
+    # via pyexcel
+toml==0.10.2
+    # via pytest
+typing-extensions==3.7.4.3
+    # via aiohttp
+ujson==4.0.1
+    # via sanic
+unidecode==1.1.1
+    # via python-slugify
+urllib3==1.26.2
+    # via
+    #   -r requirements.in
+    #   botocore
+    #   elasticsearch
+    #   requests
+uvloop==0.14.0
+    # via sanic
+vine==5.0.0
+    # via
+    #   amqp
+    #   celery
+wcwidth==0.2.5
+    # via prompt-toolkit
+websockets==8.1
+    # via sanic
+whistle==1.0.1
+    # via bonobo
+yarl==1.6.3
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Apparently now, `pip-compile` puts comment on a new line, instead of the same line which creates the big diff. Sorry for the inconvenience.

cf:
https://github.com/jazzband/pip-tools/releases
https://github.com/jazzband/pip-tools/pull/1237