### PR TITLE
Move build directive into docker-compose-dev.yml

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,4 @@
+COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml
 DJANGO_NAME=visu-back
 DJANGO_IMAGE=visu-back
 DJANGO_IMAGE_VERSION=latest

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,8 +4,14 @@ x-images:
     command: 'sh -c "while true;do echo notstarted;sleep 65000;done"'
     entrypoint: 'sh -c "while true;do echo notstarted;sleep 65000;done"'
     restart: "no"
+  django: &django
+    build:
+      context: "."
+      args:
+        PY_VER: "${DJANGO_PY_VER:-3.6}"
 services:
   django:
+    <<: [*django]
     stdin_open: true
     tty: true
     environment:
@@ -29,6 +35,7 @@ services:
       - "8006:8000"
     build: { context: ".", args: { BUILD_DEV: "y" } }
   celery:
+    <<: [*django]
     environment:
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-project.settings.dev}
     volumes:
@@ -38,6 +45,7 @@ services:
       - ./private:/code/private
       - share:/share/ # To share file between containers
   celerybeat:
+    <<: [*django]
     environment:
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-project.settings.dev}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,6 @@ x-images: # Only to create template
     tty: true
     # image: "${DJANGO_IMAGE}:${DJANGO_IMAGE_VERSION}-dev"
     # latest image is only used in prod (without dev & test tools)
-    build:
-      context: "."
-      args:
-        PY_VER: "${DJANGO_PY_VER:-3.6}"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
That way we ensure the image is never rebuilded when using
docker-compose.yml + docker-compose-prod.yml in production environment.

Also include docker-compose-dev.yml by default in the COMPOSE_FILE so a
simple `docker-compose up` will continue to work.